### PR TITLE
fix: prevent lost jokes when saving rapidly

### DIFF
--- a/src/hooks/UseJokes.ts
+++ b/src/hooks/UseJokes.ts
@@ -11,11 +11,15 @@ export const useJokes = () => {
   const [savedJokes, setSavedJokes] = useState<IJoke[]>([]);
 
   const addJoke = (joke: IJoke): boolean => {
-    if (savedJokes.some((j) => j.id === joke.id)) {
-      return false;
-    }
-    setSavedJokes([...savedJokes, joke]);
-    return true;
+    let added = false;
+    setSavedJokes((prevJokes) => {
+      if (prevJokes.some((j) => j.id === joke.id)) {
+        return prevJokes;
+      }
+      added = true;
+      return [...prevJokes, joke];
+    });
+    return added;
   };
 
   return { savedJokes, addJoke };


### PR DESCRIPTION
## Summary
- update joke-saving logic to use functional state updates and avoid stale data

## Testing
- `npm test` *(fails: react-scripts not found)*
- `npm install` *(fails: dependency conflict / forbidden package)*

------
https://chatgpt.com/codex/tasks/task_e_688ddfceee2c8325be2502b608298f5f